### PR TITLE
EIP-155 implementation

### DIFF
--- a/src/Contract.cpp
+++ b/src/Contract.cpp
@@ -11,6 +11,7 @@
 #include "Web3.h"
 #include <WiFi.h>
 #include "Util.h"
+#include "cJSON/cJSON.h"
 #include <vector>
 
 #define SIGNATURE_LENGTH 64
@@ -28,6 +29,8 @@ Contract::Contract(Web3* _web3, const char* address) {
     strcpy(options.gasPrice,"0");
     crypto = NULL;
 }
+
+Contract::Contract(long long networkId) : Contract(new Web3(networkId), "") {}
 
 void Contract::SetPrivateKey(const char *key) {
     crypto = new Crypto(web3);
@@ -137,6 +140,23 @@ string Contract::SendTransaction(uint32_t nonceVal, unsigned long long gasPriceV
     return web3->EthSendSignedTransaction(&paramStr, param.size());
 }
 
+string
+Contract::SignTransaction(uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal, string *toStr,
+                          uint256_t *valueStr, string *dataStr) {
+
+    uint8_t signature[SIGNATURE_LENGTH];
+    memset(signature, 0, SIGNATURE_LENGTH);
+    int recid[1] = {0};
+
+    GenerateSignature(signature, recid, nonceVal, gasPriceVal, gasLimitVal,
+                      toStr, valueStr, dataStr);
+
+    vector<uint8_t> param = RlpEncodeForRawTransaction(nonceVal, gasPriceVal, gasLimitVal,
+                                                       toStr, valueStr, dataStr,
+                                                       signature, recid[0]);
+    return Util::VectorToString(&param);
+}
+
 /**
  * Private functions
  **/
@@ -241,6 +261,10 @@ vector<uint8_t> Contract::RlpEncode(
     vector<uint8_t> to = Util::ConvertHexToVector(toStr);
     vector<uint8_t> value = val->export_bits_truncate();
     vector<uint8_t> data = Util::ConvertHexToVector(dataStr);
+    vector<uint8_t> chainId = Util::ConvertNumberToVector(uint32_t(web3->getChainId()));
+
+    auto *zeroStr = new string("0");
+    vector<uint8_t> zero = Util::ConvertHexToVector(zeroStr);
 
     vector<uint8_t> outputNonce = Util::RlpEncodeItemWithVector(nonce);
     vector<uint8_t> outputGasPrice = Util::RlpEncodeItemWithVector(gasPrice);
@@ -249,13 +273,19 @@ vector<uint8_t> Contract::RlpEncode(
     vector<uint8_t> outputValue = Util::RlpEncodeItemWithVector(value);
     vector<uint8_t> outputData = Util::RlpEncodeItemWithVector(data);
 
+    vector<uint8_t> outputChainId = Util::RlpEncodeItemWithVector(chainId);
+    vector<uint8_t> outputZero = Util::RlpEncodeItemWithVector(zero);
+
     vector<uint8_t> encoded = Util::RlpEncodeWholeHeaderWithVector(
         outputNonce.size() +
         outputGasPrice.size() +
         outputGasLimit.size() +
         outputTo.size() +
         outputValue.size() +
-        outputData.size());
+        outputData.size() +
+        outputChainId.size() +
+        outputZero.size() +
+        outputZero.size());
 
     encoded.insert(encoded.end(), outputNonce.begin(), outputNonce.end());
     encoded.insert(encoded.end(), outputGasPrice.begin(), outputGasPrice.end());
@@ -263,6 +293,10 @@ vector<uint8_t> Contract::RlpEncode(
     encoded.insert(encoded.end(), outputTo.begin(), outputTo.end());
     encoded.insert(encoded.end(), outputValue.begin(), outputValue.end());
     encoded.insert(encoded.end(), outputData.begin(), outputData.end());
+
+    encoded.insert(encoded.end(), outputChainId.begin(), outputChainId.end());
+    encoded.insert(encoded.end(), outputZero.begin(), outputZero.end());
+    encoded.insert(encoded.end(), outputZero.begin(), outputZero.end());
 
     return encoded;
 }
@@ -304,7 +338,7 @@ vector<uint8_t> Contract::RlpEncodeForRawTransaction(
     vector<uint8_t> S;
     S.insert(S.end(), signature.begin()+(SIGNATURE_LENGTH/2), signature.end());
     vector<uint8_t> V;
-    V.push_back((uint8_t)(recid+27)); // 27 is a magic number for Ethereum spec
+    V.push_back((uint8_t)(recid + web3->getChainId() * 2 + 35)); // according to EIP-155
     vector<uint8_t> outputR = Util::RlpEncodeItemWithVector(R);
     vector<uint8_t> outputS = Util::RlpEncodeItemWithVector(S);
     vector<uint8_t> outputV = Util::RlpEncodeItemWithVector(V);

--- a/src/Contract.h
+++ b/src/Contract.h
@@ -31,13 +31,15 @@ public:
 
 public:
     Contract(Web3* _web3, const char* address);
+    explicit Contract(long long int networkId);
     void SetPrivateKey(const char *key);
     string SetupContractData(const char* func, ...);
     string Call(const string* param);
     string ViewCall(const string *param);
     string SendTransaction(uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
                            string *toStr, uint256_t *valueStr, string *dataStr);
-
+    string SignTransaction(uint32_t nonceVal, unsigned long long int gasPriceVal, uint32_t gasLimitVal, string *toStr,
+                           uint256_t *valueStr, string *dataStr);
 private:
     Web3* web3;
     const char * contractAddress;

--- a/src/Crypto.cpp
+++ b/src/Crypto.cpp
@@ -1,367 +1,143 @@
-// Web3E Contract handling code
 //
-// By James Brown Githubs: @JamesSmartCell @AlphaWallet
-// Twitters: @TallyDigital @AlphaWallet
-//
-// Based on Web3 Arduino by Okada, Takahiro.
-//
+// Created by James Brown on 2018/09/13.
 //
 
-#include "Contract.h"
+#include <Arduino.h>
+#include "Crypto.h"
 #include "Web3.h"
-#include <WiFi.h>
 #include "Util.h"
-#include "cJSON/cJSON.h"
+#include "Trezor/secp256k1.h"
+#include "Trezor/ecdsa.h"
 #include <vector>
+#include <string.h>
 
 #define SIGNATURE_LENGTH 64
 
-/**
- * Public functions
- * */
+using namespace std;
 
-Contract::Contract(Web3* _web3, const char* address) {
+const char * PERSONAL_MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n";
+
+Crypto::Crypto(Web3* _web3) 
+{
     web3 = _web3;
-    contractAddress = address;
-    options.gas=0;
-    strcpy(options.from,"");
-    strcpy(options.to,"");
-    strcpy(options.gasPrice,"0");
-    crypto = NULL;
+    memset(privateKey, 0, ETHERS_PRIVATEKEY_LENGTH);
 }
 
-Contract::Contract(long long networkId) : Contract(new Web3(networkId), "") {}
-
-void Contract::SetPrivateKey(const char *key) {
-    crypto = new Crypto(web3);
-    crypto->SetPrivateKey(key);
-}
-
-string Contract::SetupContractData(const char* func, ...)
+bool Crypto::Sign(BYTE* digest, BYTE* result) 
 {
-    string ret = "";
-
-    string contractBytes = GenerateContractBytes(func);
-    ret = contractBytes;
-
-    size_t paramCount = 0;
-    vector<string> params;
-    char *p;
-    char tmp[strlen(func)];
-    memset(tmp, 0, sizeof(tmp));
-    strcpy(tmp, func);
-    strtok(tmp, "(");
-    p = strtok(0, "(");
-    p = strtok(p, ")");
-    p = strtok(p, ",");
-    if (p != 0) {
-        params.push_back(string(p));
-        paramCount++;
-    }
-    while(p != 0) {
-        p = strtok(0, ",");
-        if (p != 0)
-        {
-            params.push_back(string(p));
-            paramCount++;
-        }
-    }
-
-    va_list args;
-    va_start(args, func);
-    for( int i = 0; i < paramCount; ++i ) {
-        if (strstr(params[i].c_str(), "uint") != NULL && strstr(params[i].c_str(), "[]") != NULL)
-        {
-            // value array
-            string output = GenerateBytesForUIntArray(va_arg(args, vector<uint32_t> *));
-            ret = ret + output;
-        }
-        else if (strncmp(params[i].c_str(), "uint", sizeof("uint")) == 0 || strncmp(params[i].c_str(), "uint256", sizeof("uint256")) == 0)
-        {
-            string output = GenerateBytesForUint(va_arg(args, uint256_t *));
-            ret = ret + output;
-        }
-        else if (strncmp(params[i].c_str(), "int", sizeof("int")) == 0 || strncmp(params[i].c_str(), "bool", sizeof("bool")) == 0)
-        {
-            string output = GenerateBytesForInt(va_arg(args, int32_t));
-            ret = ret + string(output);
-        }
-        else if (strncmp(params[i].c_str(), "address", sizeof("address")) == 0)
-        {
-            string output = GenerateBytesForAddress(va_arg(args, string *));
-            ret = ret + string(output);
-        }
-        else if (strncmp(params[i].c_str(), "string", sizeof("string")) == 0)
-        {
-            string output = GenerateBytesForString(va_arg(args, string *));
-            ret = ret + string(output);
-        }
-        else if (strncmp(params[i].c_str(), "bytes", sizeof("bytes")) == 0) //if sending bytes, take the value in hex
-        {
-            string output = GenerateBytesForHexBytes(va_arg(args, string *));
-            ret = ret + string(output);
-        }
-    }
-    va_end(args);
-
-    return ret;
-}
-
-string Contract::ViewCall(const string *param)
-{
-    string result = web3->EthViewCall(param, contractAddress);
-    return result;
-}
-
-string Contract::Call(const string *param)
-{
-    const string from = string(options.from);
-    const long gasPrice = strtol(options.gasPrice, nullptr, 10);
-    const string value = "";
-
-    string result = web3->EthCall(&from, contractAddress, options.gas, gasPrice, &value, param);
-    return result;
-}
-
-string Contract::SendTransaction(uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
-                                 string *toStr, uint256_t *valueStr, string *dataStr)
-{
-    uint8_t signature[SIGNATURE_LENGTH];
-    memset(signature, 0, SIGNATURE_LENGTH);
-    int recid[1] = {0};
-    GenerateSignature(signature, recid, nonceVal, gasPriceVal, gasLimitVal,
-                      toStr, valueStr, dataStr);
-
-    vector<uint8_t> param = RlpEncodeForRawTransaction(nonceVal, gasPriceVal, gasLimitVal,
-                                                       toStr, valueStr, dataStr,
-                                                       signature, recid[0]);
-
-    string paramStr = Util::VectorToString(&param);
-    return web3->EthSendSignedTransaction(&paramStr, param.size());
-}
-
-string
-Contract::SignTransaction(uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal, string *toStr,
-                          uint256_t *valueStr, string *dataStr) {
-
-    uint8_t signature[SIGNATURE_LENGTH];
-    memset(signature, 0, SIGNATURE_LENGTH);
-    int recid[1] = {0};
-
-    GenerateSignature(signature, recid, nonceVal, gasPriceVal, gasLimitVal,
-                      toStr, valueStr, dataStr);
-
-    vector<uint8_t> param = RlpEncodeForRawTransaction(nonceVal, gasPriceVal, gasLimitVal,
-                                                       toStr, valueStr, dataStr,
-                                                       signature, recid[0]);
-    return Util::VectorToString(&param);
-}
-
-/**
- * Private functions
- **/
-
-void Contract::GenerateSignature(uint8_t *signature, int *recid, uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
-                                 string *toStr, uint256_t *valueStr, string *dataStr)
-{
-    vector<uint8_t> encoded = RlpEncode(nonceVal, gasPriceVal, gasLimitVal, toStr, valueStr, dataStr);
-    // hash
-    string t = Util::VectorToString(&encoded);
-
-    uint8_t *hash = new uint8_t[ETHERS_KECCAK256_LENGTH];
-    size_t encodedTxBytesLength = (t.length()-2)/2;
-    uint8_t *bytes = new uint8_t[encodedTxBytesLength];
-    Util::ConvertHexToBytes(bytes, t.c_str(), encodedTxBytesLength);
-
-    Crypto::Keccak256((uint8_t*)bytes, encodedTxBytesLength, hash);
-
-    // sign
-    Sign((uint8_t *)hash, signature, recid);
-}
-
-std::string Contract::GenerateContractBytes(const char *func)
-{
-    std::string in = Util::ConvertBytesToHex((const uint8_t *)func, strlen(func));
-    //get the hash of the input
-    std::vector<uint8_t> contractBytes = Util::ConvertHexToVector(&in);
-    std::string out = Crypto::Keccak256(&contractBytes);
-    out.resize(10);
-    return out;
-}
-
-string Contract::GenerateBytesForUint(const uint256_t *value)
-{
-    std::vector<uint8_t> bits = value->export_bits();
-    return Util::PlainVectorToString(&bits);
-}
-
-string Contract::GenerateBytesForInt(const int32_t value)
-{
-    return string(56, '0') + Util::ConvertIntegerToBytes(value);
-}
-
-string Contract::GenerateBytesForUIntArray(const vector<uint32_t> *v)
-{
-    string dynamicMarker = std::string(64, '0');
-    dynamicMarker.at(62) = '4'; //0x000...40 Array Designator
-    string arraySize = GenerateBytesForInt(v->size());
-    string output = dynamicMarker + arraySize;
-    for (auto itr = v->begin(); itr != v->end(); itr++)
+    const ecdsa_curve *curve = &secp256k1;
+    uint8_t pby;
+    int res = 0;
+    bool allZero = true;
+    for (int i = 0; i < ETHERS_PRIVATEKEY_LENGTH; i++) if (privateKey[i] != 0) allZero = false;
+    if (allZero == true)
     {
-        output += GenerateBytesForInt(*itr);
+        Serial.println("Private key not set, generate a private key (eg use Metamask) and call Contract::SetPrivateKey with it.");
     }
-
-    return output;
-}
-
-string Contract::GenerateBytesForAddress(const string *v)
-{
-    string cleaned = *v;
-    if (v->at(0) == 'x') cleaned = v->substr(1);
-    else if (v->at(1) == 'x') cleaned = v->substr(2);
-    size_t digits = cleaned.length();
-    return string(64 - digits, '0') + cleaned;
-}
-
-string Contract::GenerateBytesForString(const string *value)
-{
-    const char *valuePtr = value->c_str(); //don't fail if given a 'String'
-    size_t length = strlen(valuePtr);
-    return GenerateBytesForBytes(valuePtr, length);
-}
-
-string Contract::GenerateBytesForHexBytes(const string *value)
-{
-    string cleaned = *value;
-    if (value->at(0) == 'x') cleaned = value->substr(1);
-    else if (value->at(1) == 'x') cleaned = value->substr(2);
-    string digitsStr = Util::intToHex(cleaned.length() / 2); //bytes length will be hex length / 2
-    string lengthDesignator = string(64 - digitsStr.length(), '0') + digitsStr;
-    //write designator. TODO: This should be done for multiple inputs not just single inputs
-    lengthDesignator = "0000000000000000000000000000000000000000000000000000000000000020" + lengthDesignator;
-    cleaned = lengthDesignator + cleaned;
-    size_t digits = cleaned.length() % 64;
-    return cleaned + string(64 - digits, '0');
-}
-
-string Contract::GenerateBytesForBytes(const char *value, const int len)
-{
-    string bytesStr = Util::ConvertBytesToHex((const uint8_t *)value, len).substr(2); //clean hex prefix;
-    size_t digits = bytesStr.length();
-    return bytesStr + string(64 - digits, '0'); 
-}
-
-vector<uint8_t> Contract::RlpEncode(
-    uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
-    string *toStr, uint256_t *val, string *dataStr)
-{
-    vector<uint8_t> nonce = Util::ConvertNumberToVector(nonceVal);
-    vector<uint8_t> gasPrice = Util::ConvertNumberToVector(gasPriceVal);
-    vector<uint8_t> gasLimit = Util::ConvertNumberToVector(gasLimitVal);
-    vector<uint8_t> to = Util::ConvertHexToVector(toStr);
-    vector<uint8_t> value = val->export_bits_truncate();
-    vector<uint8_t> data = Util::ConvertHexToVector(dataStr);
-    vector<uint8_t> chainId = Util::ConvertNumberToVector(uint32_t(web3->getChainId()));
-
-    auto *zeroStr = new string("0");
-    vector<uint8_t> zero = Util::ConvertHexToVector(zeroStr);
-
-    vector<uint8_t> outputNonce = Util::RlpEncodeItemWithVector(nonce);
-    vector<uint8_t> outputGasPrice = Util::RlpEncodeItemWithVector(gasPrice);
-    vector<uint8_t> outputGasLimit = Util::RlpEncodeItemWithVector(gasLimit);
-    vector<uint8_t> outputTo = Util::RlpEncodeItemWithVector(to);
-    vector<uint8_t> outputValue = Util::RlpEncodeItemWithVector(value);
-    vector<uint8_t> outputData = Util::RlpEncodeItemWithVector(data);
-
-    vector<uint8_t> outputChainId = Util::RlpEncodeItemWithVector(chainId);
-    vector<uint8_t> outputZero = Util::RlpEncodeItemWithVector(zero);
-
-    vector<uint8_t> encoded = Util::RlpEncodeWholeHeaderWithVector(
-        outputNonce.size() +
-        outputGasPrice.size() +
-        outputGasLimit.size() +
-        outputTo.size() +
-        outputValue.size() +
-        outputData.size() +
-        outputChainId.size() +
-        outputZero.size() +
-        outputZero.size());
-
-    encoded.insert(encoded.end(), outputNonce.begin(), outputNonce.end());
-    encoded.insert(encoded.end(), outputGasPrice.begin(), outputGasPrice.end());
-    encoded.insert(encoded.end(), outputGasLimit.begin(), outputGasLimit.end());
-    encoded.insert(encoded.end(), outputTo.begin(), outputTo.end());
-    encoded.insert(encoded.end(), outputValue.begin(), outputValue.end());
-    encoded.insert(encoded.end(), outputData.begin(), outputData.end());
-
-    encoded.insert(encoded.end(), outputChainId.begin(), outputChainId.end());
-    encoded.insert(encoded.end(), outputZero.begin(), outputZero.end());
-    encoded.insert(encoded.end(), outputZero.begin(), outputZero.end());
-
-    return encoded;
-}
-
-void Contract::Sign(uint8_t *hash, uint8_t *sig, int *recid)
-{
-    BYTE fullSig[65];
-    crypto->Sign(hash, fullSig);
-    *recid = fullSig[64];
-    memcpy(sig,fullSig, 64);
-}
-
-vector<uint8_t> Contract::RlpEncodeForRawTransaction(
-    uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
-    string *toStr, uint256_t *val, string *dataStr, uint8_t *sig, uint8_t recid)
-{
-
-    vector<uint8_t> signature;
-    for (int i = 0; i < SIGNATURE_LENGTH; i++)
+    else
     {
-        signature.push_back(sig[i]);
+        res = ecdsa_sign_digest(curve, privateKey, digest, result, &pby, NULL);
+        result[64] = pby;
     }
-    vector<uint8_t> nonce = Util::ConvertNumberToVector(nonceVal);
-    vector<uint8_t> gasPrice = Util::ConvertNumberToVector(gasPriceVal);
-    vector<uint8_t> gasLimit = Util::ConvertNumberToVector(gasLimitVal);
-    vector<uint8_t> to = Util::ConvertHexToVector(toStr);
-    vector<uint8_t> value = val->export_bits_truncate();
-    vector<uint8_t> data = Util::ConvertHexToVector(dataStr);
 
-    vector<uint8_t> outputNonce = Util::RlpEncodeItemWithVector(nonce);
-    vector<uint8_t> outputGasPrice = Util::RlpEncodeItemWithVector(gasPrice);
-    vector<uint8_t> outputGasLimit = Util::RlpEncodeItemWithVector(gasLimit);
-    vector<uint8_t> outputTo = Util::RlpEncodeItemWithVector(to);
-    vector<uint8_t> outputValue = Util::RlpEncodeItemWithVector(value);
-    vector<uint8_t> outputData = Util::RlpEncodeItemWithVector(data);
+	return (res == 1);
+}
 
-    vector<uint8_t> R;
-    R.insert(R.end(), signature.begin(), signature.begin()+(SIGNATURE_LENGTH/2));
-    vector<uint8_t> S;
-    S.insert(S.end(), signature.begin()+(SIGNATURE_LENGTH/2), signature.end());
-    vector<uint8_t> V;
-    V.push_back((uint8_t)(recid + web3->getChainId() * 2 + 35)); // according to EIP-155
-    vector<uint8_t> outputR = Util::RlpEncodeItemWithVector(R);
-    vector<uint8_t> outputS = Util::RlpEncodeItemWithVector(S);
-    vector<uint8_t> outputV = Util::RlpEncodeItemWithVector(V);
-    vector<uint8_t> encoded = Util::RlpEncodeWholeHeaderWithVector(
-        outputNonce.size() +
-        outputGasPrice.size() +
-        outputGasLimit.size() +
-        outputTo.size() +
-        outputValue.size() +
-        outputData.size() +
-        outputR.size() +
-        outputS.size() +
-        outputV.size());
+void Crypto::SetPrivateKey(const char *key) 
+{
+    Util::ConvertHexToBytes(privateKey, key, ETHERS_PRIVATEKEY_LENGTH);
+}
 
-    encoded.insert(encoded.end(), outputNonce.begin(), outputNonce.end());
-    encoded.insert(encoded.end(), outputGasPrice.begin(), outputGasPrice.end());
-    encoded.insert(encoded.end(), outputGasLimit.begin(), outputGasLimit.end());
-    encoded.insert(encoded.end(), outputTo.begin(), outputTo.end());
-    encoded.insert(encoded.end(), outputValue.begin(), outputValue.end());
-    encoded.insert(encoded.end(), outputData.begin(), outputData.end());
-    encoded.insert(encoded.end(), outputV.begin(), outputV.end());
-    encoded.insert(encoded.end(), outputR.begin(), outputR.end());
-    encoded.insert(encoded.end(), outputS.begin(), outputS.end());
+void Crypto::ECRecover(BYTE* signature, BYTE *public_key, BYTE *message_hash)
+{
+    uint8_t v = signature[64]; //recover 'v' from end of signature
+	uint8_t pubkey[65];
+    uint8_t signature64[64];
+    if (v > 26) v -= 27; //correct value of 'v' if required
+    memcpy(signature64, signature, 64);
+	const ecdsa_curve *curve = &secp256k1;
+	ecdsa_recover_pub_from_sig (curve, pubkey, signature, message_hash, v);
+    memcpy(public_key, pubkey+1, 64);
+}
 
-    return encoded;
+bool Crypto::Verify(const uint8_t *public_key, const uint8_t *message_hash, const uint8_t *signature)
+{
+    const ecdsa_curve *curve = &secp256k1;
+    BYTE publicKey4[65];
+    memcpy(publicKey4+1, public_key, 64);
+    publicKey4[0] = 4;
+    int success = ecdsa_verify_digest(curve, publicKey4, signature, message_hash);
+    return (success == 0);
+}
+
+void Crypto::PrivateKeyToPublic(const uint8_t *privateKey, uint8_t *publicKey)
+{
+    uint8_t buffer[65];
+    const ecdsa_curve *curve = &secp256k1;
+    ecdsa_get_public_key65(curve, privateKey, buffer);
+    memcpy(publicKey, buffer+1, 64);
+}
+
+void Crypto::PublicKeyToAddress(const uint8_t *publicKey, uint8_t *address)
+{
+    uint8_t hashed[32];
+    Keccak256(publicKey, 64, hashed);
+    memcpy(address, &hashed[12], 20);
+}
+
+void Crypto::Keccak256(const uint8_t *data, uint16_t length, uint8_t *result)
+{
+    keccak_256(data, length, result);
+}
+
+string Crypto::Keccak256(vector<uint8_t> *bytes)
+{
+    uint8_t result[ETHERS_KECCAK256_LENGTH];
+    keccak_256(bytes->data(), bytes->size(), result);
+    //now convert result to hex string
+
+    vector<uint8_t> resultVector;
+    for (int i = 0; i < ETHERS_KECCAK256_LENGTH; i++) resultVector.push_back(result[i]);
+
+    return Util::VectorToString(&resultVector);
+}
+
+string Crypto::ECRecoverFromHexMessage(string *signature, string *message)
+{
+    uint8_t challengeHash[ETHERS_KECCAK256_LENGTH];
+    //convert hex to bytes
+    vector<uint8_t> messageBytes = Util::ConvertHexToVector((uint8_t*)(message->c_str()));
+    //hash the full challenge    
+    Crypto::Keccak256((uint8_t*)messageBytes.data(), messageBytes.size(), challengeHash);
+    return ECRecoverFromHash(signature, challengeHash);
+}
+
+string Crypto::ECRecoverFromHash(string *signature, BYTE *digest)
+{
+    //convert address to BYTE
+    BYTE signatureBytes[ETHERS_SIGNATURE_LENGTH];
+    BYTE publicKeyBytes[ETHERS_PUBLICKEY_LENGTH];
+
+    Util::ConvertHexToBytes(signatureBytes, signature->c_str(), ETHERS_SIGNATURE_LENGTH);
+
+    // Perform ECRecover to get the public key - this extracts the public key of the private key
+    // that was used to sign the message - that is, the private key held by the wallet/metamask
+    Crypto::ECRecover(signatureBytes, publicKeyBytes, digest); 
+
+    BYTE recoverAddr[ETHERS_ADDRESS_LENGTH];
+    // Now reduce the recovered public key to Ethereum address
+    Crypto::PublicKeyToAddress(publicKeyBytes, recoverAddr);
+    string recoveredAddress = Util::ConvertBytesToHex(recoverAddr, ETHERS_ADDRESS_LENGTH);
+    return recoveredAddress;
+}
+
+string Crypto::ECRecoverFromPersonalMessage(string *signature, string *message)
+{
+    uint8_t challengeHash[ETHERS_KECCAK256_LENGTH];
+    string challengeStr = PERSONAL_MESSAGE_PREFIX;
+    challengeStr += Util::toString((int)message->length());
+    challengeStr += *message;
+
+    Crypto::Keccak256((uint8_t*)challengeStr.c_str(), challengeStr.length(), challengeHash);
+    return ECRecoverFromHash(signature, challengeHash);
 }

--- a/src/Crypto.cpp
+++ b/src/Crypto.cpp
@@ -1,143 +1,367 @@
+// Web3E Contract handling code
 //
-// Created by James Brown on 2018/09/13.
+// By James Brown Githubs: @JamesSmartCell @AlphaWallet
+// Twitters: @TallyDigital @AlphaWallet
+//
+// Based on Web3 Arduino by Okada, Takahiro.
+//
 //
 
-#include <Arduino.h>
-#include "Crypto.h"
+#include "Contract.h"
 #include "Web3.h"
+#include <WiFi.h>
 #include "Util.h"
-#include "Trezor/secp256k1.h"
-#include "Trezor/ecdsa.h"
+#include "cJSON/cJSON.h"
 #include <vector>
-#include <string.h>
 
 #define SIGNATURE_LENGTH 64
 
-using namespace std;
+/**
+ * Public functions
+ * */
 
-const char * PERSONAL_MESSAGE_PREFIX = "\u0019Ethereum Signed Message:\n";
-
-Crypto::Crypto(Web3* _web3) 
-{
+Contract::Contract(Web3* _web3, const char* address) {
     web3 = _web3;
-    memset(privateKey, 0, ETHERS_PRIVATEKEY_LENGTH);
+    contractAddress = address;
+    options.gas=0;
+    strcpy(options.from,"");
+    strcpy(options.to,"");
+    strcpy(options.gasPrice,"0");
+    crypto = NULL;
 }
 
-bool Crypto::Sign(BYTE* digest, BYTE* result) 
+Contract::Contract(long long networkId) : Contract(new Web3(networkId), "") {}
+
+void Contract::SetPrivateKey(const char *key) {
+    crypto = new Crypto(web3);
+    crypto->SetPrivateKey(key);
+}
+
+string Contract::SetupContractData(const char* func, ...)
 {
-    const ecdsa_curve *curve = &secp256k1;
-    uint8_t pby;
-    int res = 0;
-    bool allZero = true;
-    for (int i = 0; i < ETHERS_PRIVATEKEY_LENGTH; i++) if (privateKey[i] != 0) allZero = false;
-    if (allZero == true)
-    {
-        Serial.println("Private key not set, generate a private key (eg use Metamask) and call Contract::SetPrivateKey with it.");
+    string ret = "";
+
+    string contractBytes = GenerateContractBytes(func);
+    ret = contractBytes;
+
+    size_t paramCount = 0;
+    vector<string> params;
+    char *p;
+    char tmp[strlen(func)];
+    memset(tmp, 0, sizeof(tmp));
+    strcpy(tmp, func);
+    strtok(tmp, "(");
+    p = strtok(0, "(");
+    p = strtok(p, ")");
+    p = strtok(p, ",");
+    if (p != 0) {
+        params.push_back(string(p));
+        paramCount++;
     }
-    else
-    {
-        res = ecdsa_sign_digest(curve, privateKey, digest, result, &pby, NULL);
-        result[64] = pby;
+    while(p != 0) {
+        p = strtok(0, ",");
+        if (p != 0)
+        {
+            params.push_back(string(p));
+            paramCount++;
+        }
     }
 
-	return (res == 1);
+    va_list args;
+    va_start(args, func);
+    for( int i = 0; i < paramCount; ++i ) {
+        if (strstr(params[i].c_str(), "uint") != NULL && strstr(params[i].c_str(), "[]") != NULL)
+        {
+            // value array
+            string output = GenerateBytesForUIntArray(va_arg(args, vector<uint32_t> *));
+            ret = ret + output;
+        }
+        else if (strncmp(params[i].c_str(), "uint", sizeof("uint")) == 0 || strncmp(params[i].c_str(), "uint256", sizeof("uint256")) == 0)
+        {
+            string output = GenerateBytesForUint(va_arg(args, uint256_t *));
+            ret = ret + output;
+        }
+        else if (strncmp(params[i].c_str(), "int", sizeof("int")) == 0 || strncmp(params[i].c_str(), "bool", sizeof("bool")) == 0)
+        {
+            string output = GenerateBytesForInt(va_arg(args, int32_t));
+            ret = ret + string(output);
+        }
+        else if (strncmp(params[i].c_str(), "address", sizeof("address")) == 0)
+        {
+            string output = GenerateBytesForAddress(va_arg(args, string *));
+            ret = ret + string(output);
+        }
+        else if (strncmp(params[i].c_str(), "string", sizeof("string")) == 0)
+        {
+            string output = GenerateBytesForString(va_arg(args, string *));
+            ret = ret + string(output);
+        }
+        else if (strncmp(params[i].c_str(), "bytes", sizeof("bytes")) == 0) //if sending bytes, take the value in hex
+        {
+            string output = GenerateBytesForHexBytes(va_arg(args, string *));
+            ret = ret + string(output);
+        }
+    }
+    va_end(args);
+
+    return ret;
 }
 
-void Crypto::SetPrivateKey(const char *key) 
+string Contract::ViewCall(const string *param)
 {
-    Util::ConvertHexToBytes(privateKey, key, ETHERS_PRIVATEKEY_LENGTH);
+    string result = web3->EthViewCall(param, contractAddress);
+    return result;
 }
 
-void Crypto::ECRecover(BYTE* signature, BYTE *public_key, BYTE *message_hash)
+string Contract::Call(const string *param)
 {
-    uint8_t v = signature[64]; //recover 'v' from end of signature
-	uint8_t pubkey[65];
-    uint8_t signature64[64];
-    if (v > 26) v -= 27; //correct value of 'v' if required
-    memcpy(signature64, signature, 64);
-	const ecdsa_curve *curve = &secp256k1;
-	ecdsa_recover_pub_from_sig (curve, pubkey, signature, message_hash, v);
-    memcpy(public_key, pubkey+1, 64);
+    const string from = string(options.from);
+    const long gasPrice = strtol(options.gasPrice, nullptr, 10);
+    const string value = "";
+
+    string result = web3->EthCall(&from, contractAddress, options.gas, gasPrice, &value, param);
+    return result;
 }
 
-bool Crypto::Verify(const uint8_t *public_key, const uint8_t *message_hash, const uint8_t *signature)
+string Contract::SendTransaction(uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
+                                 string *toStr, uint256_t *valueStr, string *dataStr)
 {
-    const ecdsa_curve *curve = &secp256k1;
-    BYTE publicKey4[65];
-    memcpy(publicKey4+1, public_key, 64);
-    publicKey4[0] = 4;
-    int success = ecdsa_verify_digest(curve, publicKey4, signature, message_hash);
-    return (success == 0);
+    uint8_t signature[SIGNATURE_LENGTH];
+    memset(signature, 0, SIGNATURE_LENGTH);
+    int recid[1] = {0};
+    GenerateSignature(signature, recid, nonceVal, gasPriceVal, gasLimitVal,
+                      toStr, valueStr, dataStr);
+
+    vector<uint8_t> param = RlpEncodeForRawTransaction(nonceVal, gasPriceVal, gasLimitVal,
+                                                       toStr, valueStr, dataStr,
+                                                       signature, recid[0]);
+
+    string paramStr = Util::VectorToString(&param);
+    return web3->EthSendSignedTransaction(&paramStr, param.size());
 }
 
-void Crypto::PrivateKeyToPublic(const uint8_t *privateKey, uint8_t *publicKey)
-{
-    uint8_t buffer[65];
-    const ecdsa_curve *curve = &secp256k1;
-    ecdsa_get_public_key65(curve, privateKey, buffer);
-    memcpy(publicKey, buffer+1, 64);
+string
+Contract::SignTransaction(uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal, string *toStr,
+                          uint256_t *valueStr, string *dataStr) {
+
+    uint8_t signature[SIGNATURE_LENGTH];
+    memset(signature, 0, SIGNATURE_LENGTH);
+    int recid[1] = {0};
+
+    GenerateSignature(signature, recid, nonceVal, gasPriceVal, gasLimitVal,
+                      toStr, valueStr, dataStr);
+
+    vector<uint8_t> param = RlpEncodeForRawTransaction(nonceVal, gasPriceVal, gasLimitVal,
+                                                       toStr, valueStr, dataStr,
+                                                       signature, recid[0]);
+    return Util::VectorToString(&param);
 }
 
-void Crypto::PublicKeyToAddress(const uint8_t *publicKey, uint8_t *address)
+/**
+ * Private functions
+ **/
+
+void Contract::GenerateSignature(uint8_t *signature, int *recid, uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
+                                 string *toStr, uint256_t *valueStr, string *dataStr)
 {
-    uint8_t hashed[32];
-    Keccak256(publicKey, 64, hashed);
-    memcpy(address, &hashed[12], 20);
+    vector<uint8_t> encoded = RlpEncode(nonceVal, gasPriceVal, gasLimitVal, toStr, valueStr, dataStr);
+    // hash
+    string t = Util::VectorToString(&encoded);
+
+    uint8_t *hash = new uint8_t[ETHERS_KECCAK256_LENGTH];
+    size_t encodedTxBytesLength = (t.length()-2)/2;
+    uint8_t *bytes = new uint8_t[encodedTxBytesLength];
+    Util::ConvertHexToBytes(bytes, t.c_str(), encodedTxBytesLength);
+
+    Crypto::Keccak256((uint8_t*)bytes, encodedTxBytesLength, hash);
+
+    // sign
+    Sign((uint8_t *)hash, signature, recid);
 }
 
-void Crypto::Keccak256(const uint8_t *data, uint16_t length, uint8_t *result)
+std::string Contract::GenerateContractBytes(const char *func)
 {
-    keccak_256(data, length, result);
+    std::string in = Util::ConvertBytesToHex((const uint8_t *)func, strlen(func));
+    //get the hash of the input
+    std::vector<uint8_t> contractBytes = Util::ConvertHexToVector(&in);
+    std::string out = Crypto::Keccak256(&contractBytes);
+    out.resize(10);
+    return out;
 }
 
-string Crypto::Keccak256(vector<uint8_t> *bytes)
+string Contract::GenerateBytesForUint(const uint256_t *value)
 {
-    uint8_t result[ETHERS_KECCAK256_LENGTH];
-    keccak_256(bytes->data(), bytes->size(), result);
-    //now convert result to hex string
-
-    vector<uint8_t> resultVector;
-    for (int i = 0; i < ETHERS_KECCAK256_LENGTH; i++) resultVector.push_back(result[i]);
-
-    return Util::VectorToString(&resultVector);
+    std::vector<uint8_t> bits = value->export_bits();
+    return Util::PlainVectorToString(&bits);
 }
 
-string Crypto::ECRecoverFromHexMessage(string *signature, string *message)
+string Contract::GenerateBytesForInt(const int32_t value)
 {
-    uint8_t challengeHash[ETHERS_KECCAK256_LENGTH];
-    //convert hex to bytes
-    vector<uint8_t> messageBytes = Util::ConvertHexToVector((uint8_t*)(message->c_str()));
-    //hash the full challenge    
-    Crypto::Keccak256((uint8_t*)messageBytes.data(), messageBytes.size(), challengeHash);
-    return ECRecoverFromHash(signature, challengeHash);
+    return string(56, '0') + Util::ConvertIntegerToBytes(value);
 }
 
-string Crypto::ECRecoverFromHash(string *signature, BYTE *digest)
+string Contract::GenerateBytesForUIntArray(const vector<uint32_t> *v)
 {
-    //convert address to BYTE
-    BYTE signatureBytes[ETHERS_SIGNATURE_LENGTH];
-    BYTE publicKeyBytes[ETHERS_PUBLICKEY_LENGTH];
+    string dynamicMarker = std::string(64, '0');
+    dynamicMarker.at(62) = '4'; //0x000...40 Array Designator
+    string arraySize = GenerateBytesForInt(v->size());
+    string output = dynamicMarker + arraySize;
+    for (auto itr = v->begin(); itr != v->end(); itr++)
+    {
+        output += GenerateBytesForInt(*itr);
+    }
 
-    Util::ConvertHexToBytes(signatureBytes, signature->c_str(), ETHERS_SIGNATURE_LENGTH);
-
-    // Perform ECRecover to get the public key - this extracts the public key of the private key
-    // that was used to sign the message - that is, the private key held by the wallet/metamask
-    Crypto::ECRecover(signatureBytes, publicKeyBytes, digest); 
-
-    BYTE recoverAddr[ETHERS_ADDRESS_LENGTH];
-    // Now reduce the recovered public key to Ethereum address
-    Crypto::PublicKeyToAddress(publicKeyBytes, recoverAddr);
-    string recoveredAddress = Util::ConvertBytesToHex(recoverAddr, ETHERS_ADDRESS_LENGTH);
-    return recoveredAddress;
+    return output;
 }
 
-string Crypto::ECRecoverFromPersonalMessage(string *signature, string *message)
+string Contract::GenerateBytesForAddress(const string *v)
 {
-    uint8_t challengeHash[ETHERS_KECCAK256_LENGTH];
-    string challengeStr = PERSONAL_MESSAGE_PREFIX;
-    challengeStr += Util::toString((int)message->length());
-    challengeStr += *message;
+    string cleaned = *v;
+    if (v->at(0) == 'x') cleaned = v->substr(1);
+    else if (v->at(1) == 'x') cleaned = v->substr(2);
+    size_t digits = cleaned.length();
+    return string(64 - digits, '0') + cleaned;
+}
 
-    Crypto::Keccak256((uint8_t*)challengeStr.c_str(), challengeStr.length(), challengeHash);
-    return ECRecoverFromHash(signature, challengeHash);
+string Contract::GenerateBytesForString(const string *value)
+{
+    const char *valuePtr = value->c_str(); //don't fail if given a 'String'
+    size_t length = strlen(valuePtr);
+    return GenerateBytesForBytes(valuePtr, length);
+}
+
+string Contract::GenerateBytesForHexBytes(const string *value)
+{
+    string cleaned = *value;
+    if (value->at(0) == 'x') cleaned = value->substr(1);
+    else if (value->at(1) == 'x') cleaned = value->substr(2);
+    string digitsStr = Util::intToHex(cleaned.length() / 2); //bytes length will be hex length / 2
+    string lengthDesignator = string(64 - digitsStr.length(), '0') + digitsStr;
+    //write designator. TODO: This should be done for multiple inputs not just single inputs
+    lengthDesignator = "0000000000000000000000000000000000000000000000000000000000000020" + lengthDesignator;
+    cleaned = lengthDesignator + cleaned;
+    size_t digits = cleaned.length() % 64;
+    return cleaned + string(64 - digits, '0');
+}
+
+string Contract::GenerateBytesForBytes(const char *value, const int len)
+{
+    string bytesStr = Util::ConvertBytesToHex((const uint8_t *)value, len).substr(2); //clean hex prefix;
+    size_t digits = bytesStr.length();
+    return bytesStr + string(64 - digits, '0'); 
+}
+
+vector<uint8_t> Contract::RlpEncode(
+    uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
+    string *toStr, uint256_t *val, string *dataStr)
+{
+    vector<uint8_t> nonce = Util::ConvertNumberToVector(nonceVal);
+    vector<uint8_t> gasPrice = Util::ConvertNumberToVector(gasPriceVal);
+    vector<uint8_t> gasLimit = Util::ConvertNumberToVector(gasLimitVal);
+    vector<uint8_t> to = Util::ConvertHexToVector(toStr);
+    vector<uint8_t> value = val->export_bits_truncate();
+    vector<uint8_t> data = Util::ConvertHexToVector(dataStr);
+    vector<uint8_t> chainId = Util::ConvertNumberToVector(uint32_t(web3->getChainId()));
+
+    auto *zeroStr = new string("0");
+    vector<uint8_t> zero = Util::ConvertHexToVector(zeroStr);
+
+    vector<uint8_t> outputNonce = Util::RlpEncodeItemWithVector(nonce);
+    vector<uint8_t> outputGasPrice = Util::RlpEncodeItemWithVector(gasPrice);
+    vector<uint8_t> outputGasLimit = Util::RlpEncodeItemWithVector(gasLimit);
+    vector<uint8_t> outputTo = Util::RlpEncodeItemWithVector(to);
+    vector<uint8_t> outputValue = Util::RlpEncodeItemWithVector(value);
+    vector<uint8_t> outputData = Util::RlpEncodeItemWithVector(data);
+
+    vector<uint8_t> outputChainId = Util::RlpEncodeItemWithVector(chainId);
+    vector<uint8_t> outputZero = Util::RlpEncodeItemWithVector(zero);
+
+    vector<uint8_t> encoded = Util::RlpEncodeWholeHeaderWithVector(
+        outputNonce.size() +
+        outputGasPrice.size() +
+        outputGasLimit.size() +
+        outputTo.size() +
+        outputValue.size() +
+        outputData.size() +
+        outputChainId.size() +
+        outputZero.size() +
+        outputZero.size());
+
+    encoded.insert(encoded.end(), outputNonce.begin(), outputNonce.end());
+    encoded.insert(encoded.end(), outputGasPrice.begin(), outputGasPrice.end());
+    encoded.insert(encoded.end(), outputGasLimit.begin(), outputGasLimit.end());
+    encoded.insert(encoded.end(), outputTo.begin(), outputTo.end());
+    encoded.insert(encoded.end(), outputValue.begin(), outputValue.end());
+    encoded.insert(encoded.end(), outputData.begin(), outputData.end());
+
+    encoded.insert(encoded.end(), outputChainId.begin(), outputChainId.end());
+    encoded.insert(encoded.end(), outputZero.begin(), outputZero.end());
+    encoded.insert(encoded.end(), outputZero.begin(), outputZero.end());
+
+    return encoded;
+}
+
+void Contract::Sign(uint8_t *hash, uint8_t *sig, int *recid)
+{
+    BYTE fullSig[65];
+    crypto->Sign(hash, fullSig);
+    *recid = fullSig[64];
+    memcpy(sig,fullSig, 64);
+}
+
+vector<uint8_t> Contract::RlpEncodeForRawTransaction(
+    uint32_t nonceVal, unsigned long long gasPriceVal, uint32_t gasLimitVal,
+    string *toStr, uint256_t *val, string *dataStr, uint8_t *sig, uint8_t recid)
+{
+
+    vector<uint8_t> signature;
+    for (int i = 0; i < SIGNATURE_LENGTH; i++)
+    {
+        signature.push_back(sig[i]);
+    }
+    vector<uint8_t> nonce = Util::ConvertNumberToVector(nonceVal);
+    vector<uint8_t> gasPrice = Util::ConvertNumberToVector(gasPriceVal);
+    vector<uint8_t> gasLimit = Util::ConvertNumberToVector(gasLimitVal);
+    vector<uint8_t> to = Util::ConvertHexToVector(toStr);
+    vector<uint8_t> value = val->export_bits_truncate();
+    vector<uint8_t> data = Util::ConvertHexToVector(dataStr);
+
+    vector<uint8_t> outputNonce = Util::RlpEncodeItemWithVector(nonce);
+    vector<uint8_t> outputGasPrice = Util::RlpEncodeItemWithVector(gasPrice);
+    vector<uint8_t> outputGasLimit = Util::RlpEncodeItemWithVector(gasLimit);
+    vector<uint8_t> outputTo = Util::RlpEncodeItemWithVector(to);
+    vector<uint8_t> outputValue = Util::RlpEncodeItemWithVector(value);
+    vector<uint8_t> outputData = Util::RlpEncodeItemWithVector(data);
+
+    vector<uint8_t> R;
+    R.insert(R.end(), signature.begin(), signature.begin()+(SIGNATURE_LENGTH/2));
+    vector<uint8_t> S;
+    S.insert(S.end(), signature.begin()+(SIGNATURE_LENGTH/2), signature.end());
+    vector<uint8_t> V;
+    V.push_back((uint8_t)(recid + web3->getChainId() * 2 + 35)); // according to EIP-155
+    vector<uint8_t> outputR = Util::RlpEncodeItemWithVector(R);
+    vector<uint8_t> outputS = Util::RlpEncodeItemWithVector(S);
+    vector<uint8_t> outputV = Util::RlpEncodeItemWithVector(V);
+    vector<uint8_t> encoded = Util::RlpEncodeWholeHeaderWithVector(
+        outputNonce.size() +
+        outputGasPrice.size() +
+        outputGasLimit.size() +
+        outputTo.size() +
+        outputValue.size() +
+        outputData.size() +
+        outputR.size() +
+        outputS.size() +
+        outputV.size());
+
+    encoded.insert(encoded.end(), outputNonce.begin(), outputNonce.end());
+    encoded.insert(encoded.end(), outputGasPrice.begin(), outputGasPrice.end());
+    encoded.insert(encoded.end(), outputGasLimit.begin(), outputGasLimit.end());
+    encoded.insert(encoded.end(), outputTo.begin(), outputTo.end());
+    encoded.insert(encoded.end(), outputValue.begin(), outputValue.end());
+    encoded.insert(encoded.end(), outputData.begin(), outputData.end());
+    encoded.insert(encoded.end(), outputV.begin(), outputV.end());
+    encoded.insert(encoded.end(), outputR.begin(), outputR.end());
+    encoded.insert(encoded.end(), outputS.begin(), outputS.end());
+
+    return encoded;
 }

--- a/src/Web3.cpp
+++ b/src/Web3.cpp
@@ -10,7 +10,7 @@
 #include "Web3.h"
 #include "Certificates.h"
 #include "Util.h"
-#include "cJSON/cJSON.h"
+#include "TagReader/TagReader.h"
 #include <iostream>
 #include <sstream>
 #include "nodes.h"
@@ -94,17 +94,7 @@ bool Web3::EthSyncing() {
     string input = generateJson(&m, &p);
     string result = exec(&input);
 
-    cJSON *root, *value;
-    root = cJSON_Parse(result.c_str());
-    value = cJSON_GetObjectItem(root, "result");
-    bool ret;
-    if (cJSON_IsBool(value)) {
-        ret = false;
-    } else{
-        ret = true;
-    }
-    cJSON_free(root);
-    return ret;
+    return getBool(&result);
 }
 
 bool Web3::EthMining() {
@@ -254,92 +244,66 @@ string Web3::exec(const string* data) {
 }
 
 int Web3::getInt(const string* json) {
-    int ret = -1;
-    cJSON *root, *value;
-    root = cJSON_Parse(json->c_str());
-    value = cJSON_GetObjectItem(root, "result");
-    if (cJSON_IsString(value)) {
-        ret = strtol(value->valuestring, nullptr, 16);
-    }
-    cJSON_free(root);
-    return ret;
+    TagReader reader;
+    string parseVal = reader.getTag(json, "result");
+    return strtol(parseVal.c_str(), nullptr, 16);
 }
 
 long Web3::getLong(const string* json) {
-    long ret = -1;
-    cJSON *root, *value;
-    root = cJSON_Parse(json->c_str());
-    value = cJSON_GetObjectItem(root, "result");
-    if (cJSON_IsString(value)) {
-        ret = strtol(value->valuestring, nullptr, 16);
-    }
-    cJSON_free(root);
-    return ret;
+    TagReader reader;
+    string parseVal = reader.getTag(json, "result");
+    return strtol(parseVal.c_str(), nullptr, 16);
 }
 
 long long int Web3::getLongLong(const string* json) {
-    long long int ret = -1;
-    cJSON *root, *value;
-    root = cJSON_Parse(json->c_str());
-    value = cJSON_GetObjectItem(root, "result");
-    if (cJSON_IsString(value)) {
-        ret = strtoll(value->valuestring, nullptr, 16);
-    }
-    cJSON_free(root);
-    return ret;
+    TagReader reader;
+    string parseVal = reader.getTag(json, "result");
+    return strtoll(parseVal.c_str(), nullptr, 16);
 }
 
 uint256_t Web3::getUint256(const string* json) {
-    uint256_t ret = 0;
-    cJSON *root, *value;
-    root = cJSON_Parse(json->c_str());
-    value = cJSON_GetObjectItem(root, "result");
-    if (cJSON_IsString(value)) {
-        ret = uint256_t(value->valuestring);
-    }
-    cJSON_free(root);
-    return ret;
+    TagReader reader;
+    string parseVal = reader.getTag(json, "result");
+    return uint256_t(parseVal.c_str());
 }
 
 double Web3::getDouble(const string* json) {
-    double ret = -1;
-    cJSON *root, *value;
-    root = cJSON_Parse(json->c_str());
-    value = cJSON_GetObjectItem(root, "result");
-    if (cJSON_IsString(value)) {
-        ret = strtof(value->valuestring, nullptr);
-    }
-    cJSON_free(root);
-    return ret;
+    TagReader reader;
+    string parseVal = reader.getTag(json, "result");
+    return strtof(parseVal.c_str(), nullptr);
 }
 
 bool Web3::getBool(const string* json) {
-    bool ret = false;
-    cJSON *root, *value;
-    root = cJSON_Parse(json->c_str());
-    value = cJSON_GetObjectItem(root, "result");
-    if (cJSON_IsBool(value)) {
-        ret = (bool)value->valueint;
-    }
-    cJSON_free(root);
-    return ret;
+    TagReader reader;
+    string parseVal = reader.getTag(json, "result");
+    long v = strtol(parseVal.c_str(), nullptr, 16);
+    return v > 0;
 }
 
+//Currently only works for string return eg: function name() returns (string)
 string Web3::getString(const string *json)
 {
-    cJSON *root, *value;
-    if (json->find("result") >= 0)
+    TagReader reader;
+    string parseVal = reader.getTag(json, "result");
+    vector<string> *v = Util::ConvertStringHexToABIArray(&parseVal);
+    
+    uint256_t length = uint256_t(v->at(1));
+    int lengthIndex = (size_t)length;
+
+    string asciiHex;
+    int index = 2;
+    while (lengthIndex > 0)
     {
-        root = cJSON_Parse(json->c_str());
-        value = cJSON_GetObjectItem(root, "result");
-        if (value != NULL && cJSON_IsString(value))
-        {
-            cJSON_free(root);
-            return string(value->valuestring);
-        }
-        cJSON_free(root);
+        Serial.println(index);
+        asciiHex += v->at(index++);
+        lengthIndex -= 32;
     }
-    return string("");
+
+    //convert ascii into string
+    string text = Util::ConvertHexToASCII(asciiHex.substr(0, length*2).c_str(), length*2);
+    delete v;
+
+    return text;
 }
 
 /**
@@ -402,6 +366,7 @@ void Web3::selectHost()
         path = "/";
     }
 }
+
 
 long long Web3::getChainId() const {
     return chainId;

--- a/src/Web3.h
+++ b/src/Web3.h
@@ -72,6 +72,7 @@ public:
     string getString(const string* json);
     int getInt(const string* json);
     uint256_t getUint256(const string* json);
+    long long int getChainId() const;
 
 private:
     string exec(const string* data);


### PR DESCRIPTION
I once again reviewed previous changes and made some refactor to be able to provide EIP-155 to library without breaking anything. Now this implementation only changes signatures to include chain id.

- [ v]  added constructor to `explicit Contract(long long int networkId);`, now we dont have to create new web3 obj to send transaction, just provide chainid
- [ v] added fn `SignTransaction(...)` to be able just for signing
- [ v] added getter to web3 `getChainId()` to be able to retrive chainId